### PR TITLE
bottle :unneeded is deprecated

### DIFF
--- a/kagiana.rb
+++ b/kagiana.rb
@@ -3,7 +3,6 @@ class Kagiana < Formula
   desc "Kagiana for Vault"
   homepage "https://github.com/pyama86/kagiana"
   version "0.4.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/pyama86/kagiana/releases/download/v0.4.2/kagiana_0.4.2_darwin_amd64.tar.gz"


### PR DESCRIPTION
Hi @pyama86 

Remove `bottle :unneeded`. because `Calling bottle :unneeded is deprecated`.

When executing `brew *` command, a warning message is displayed as follows.
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the pyama86/kagiana tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/pyama86/homebrew-kagiana/kagiana.rb:6
Warning: Calling bottle :unneeded is deprecated! There is no
replacement.
```